### PR TITLE
Now detects changes to munge-key

### DIFF
--- a/src/reactive/slurm_node.py
+++ b/src/reactive/slurm_node.py
@@ -77,6 +77,11 @@ def configure_node(cluster_changed, cluster_joined):
     flags.clear_flag('endpoint.slurm-cluster.active.changed')
     log('Cleared {} flag'.format('endpoint.slurm-cluster.active.changed'))
 
+    # Clear this flag to be able to signal munge_key changed if it occurs from
+    # a controller.
+    flags.clear_flag('endpoint.slurm-cluster.changed.munge_key')
+    log('Cleared {} flag'.format('endpoint.slurm-cluster.changed.munge_key'))
+
 
 @reactive.when('endpoint.slurm-cluster.joined', 'slurm-node.configured')
 def node_ready(cluster_endpoint):


### PR DESCRIPTION
By clearing the "endpoint.slurm-cluster.changed.munge_key" , the node picks up the information that the munge key is being changed by the controller.

Once the slurm-node implements the "munge-interface" - then - propagating the munge-key via the slurm-cluster interface may be removed altogether.